### PR TITLE
refactor: Use specific ImportError instead of broad Exception

### DIFF
--- a/twitter_cli/client.py
+++ b/twitter_cli/client.py
@@ -76,7 +76,9 @@ def _best_chrome_target():
     try:
         from curl_cffi.requests import BrowserType
         available = {e.value for e in BrowserType}
-    except Exception:
+    except ImportError:
+        # curl_cffi not installed or BrowserType not available
+        logger.debug("curl_cffi.BrowserType not available, using fallback targets")
         available = set()
 
     # Preference order: exact chrome versions, then suffixed variants


### PR DESCRIPTION
## Changes

Changed the exception handling in `_best_chrome_target()` to catch specific `ImportError` instead of broad `Exception`. This improves code clarity and avoids masking unexpected errors.

Also added a debug log message to help diagnose when curl_cffi is not available.

## Benefits

1. **More specific error handling**: ImportError is the expected exception when curl_cffi is not installed
2. **Better debugging**: Added debug log to help diagnose import issues
3. **Follows Python best practices**: Avoid catching broad Exception when possible

## Testing

- [ ] Test with curl_cffi installed
- [ ] Test without curl_cffi installed

This is a minor refactoring that should not change any behavior.