### PR TITLE
feat: add twitter article command for long-form Twitter Articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A terminal-first CLI for Twitter/X: read timelines, bookmarks, and user profiles
 - Bookmarks: list saved tweets from your account
 - Search: find tweets by keyword with Top/Latest/Photos/Videos tabs
 - Tweet detail: view a tweet and its replies
+- Article: fetch long-form Twitter Articles (rendered as Markdown in the terminal)
 - List timeline: fetch tweets from a Twitter List
 - User lookup: fetch user profile, tweets, likes, followers, and following
 - Structured output: export any data as YAML or JSON for scripting and AI agent integration
@@ -111,6 +112,11 @@ twitter search "trending" --filter              # Apply ranking filter
 # Tweet detail (view tweet + replies)
 twitter tweet 1234567890
 twitter tweet https://x.com/user/status/1234567890
+
+# Article (long-form Twitter Article)
+twitter article 1234567890
+twitter article https://x.com/user/article/1234567890  # /article/ URL also accepted
+twitter article 1234567890 --json
 
 # List timeline
 twitter list 1539453138322673664
@@ -278,16 +284,16 @@ Current CI validates the project on Python 3.8, 3.10, and 3.12.
 ```text
 twitter_cli/
 ├── __init__.py
-├── cli.py
-├── client.py
+├── cli.py           # CLI commands (entry point for all subcommands)
+├── client.py        # API methods — one method per Twitter feature
 ├── graphql.py       # GraphQL query IDs, URL building, JS bundle scanning
-├── parser.py        # Tweet, User, Media parsing logic
+├── parser.py        # Tweet, User, Media, Article parsing logic
 ├── auth.py
 ├── config.py
 ├── constants.py
 ├── exceptions.py
 ├── filter.py
-├── formatter.py
+├── formatter.py     # Rich terminal rendering (tables, panels, Markdown)
 ├── output.py
 ├── serialization.py
 └── models.py
@@ -328,6 +334,7 @@ After installation, OpenClaw can call `twitter-cli` commands directly.
 - 收藏读取：查看账号书签推文
 - 搜索：按关键词搜索推文，支持 Top/Latest/Photos/Videos
 - 推文详情：查看推文及其回复
+- 文章读取：获取 Twitter 长文（Articles），在终端以 Markdown 格式渲染
 - 列表时间线：获取 Twitter List 的推文
 - 用户查询：查看用户资料、推文、点赞、粉丝和关注
 - 结构化输出：支持 YAML 和 JSON，便于脚本处理和 AI agent 集成
@@ -386,6 +393,11 @@ twitter search "trending" --filter              # 启用排序筛选
 
 # 推文详情
 twitter tweet 1234567890
+
+# 文章（长文 Twitter Article）
+twitter article 1234567890
+twitter article https://x.com/user/article/1234567890  # 支持 /article/ 格式链接
+twitter article 1234567890 --json
 
 # 列表时间线
 twitter list 1539453138322673664

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -27,7 +27,29 @@ error:
 - tweet and user lists are returned under `data`
 - `status` returns `data.authenticated` plus `data.user`
 - `whoami` returns `data.user`
+- `article` returns a **single tweet object** (not an array) directly under `data`
 - write commands also support explicit `--json` / `--yaml`
+
+## Article Fields
+
+`twitter article <id>` returns a standard tweet object with two additional fields:
+
+```yaml
+ok: true
+schema_version: "1"
+data:
+  id: "1234567890"
+  text: "https://t.co/..."        # Short URL pointing to the article
+  author: { ... }                 # Standard author object
+  metrics: { ... }                # Standard engagement metrics
+  articleTitle: "Article Title"   # Present only on article tweets; null otherwise
+  articleText: |                  # Full article body converted to Markdown
+    ## Heading
+    Paragraph text...
+  # ... all other standard tweet fields
+```
+
+`articleTitle` and `articleText` are `null` on regular (non-article) tweets.
 
 ## Error Codes
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: twitter-cli
-description: Use twitter-cli for ALL Twitter/X operations — reading tweets, posting, replying, quoting, liking, retweeting, following, searching, user lookups. Invoke whenever user requests any Twitter interaction.
+description: Use twitter-cli for ALL Twitter/X operations — reading tweets, articles, posting, replying, quoting, liking, retweeting, following, searching, user lookups. Invoke whenever user requests any Twitter interaction.
 author: jackwener
 version: "2.0.0"
 tags:
@@ -148,6 +148,9 @@ twitter search "AI agent" -t Latest --max 50
 twitter search "topic" -o results.json # Save to file
 twitter tweet 1234567890               # Tweet detail + replies
 twitter tweet https://x.com/user/status/12345  # Accepts URL
+twitter article 1234567890             # Twitter Article (long-form post, body as Markdown)
+twitter article https://x.com/user/article/12345  # Accepts /article/ URL
+twitter article 1234567890 --json      # Structured output with articleTitle + articleText
 twitter list 1539453138322673664       # List timeline
 twitter user-posts elonmusk --max 20   # User's tweets
 twitter likes elonmusk --max 30        # User's likes (own only, see note)
@@ -234,6 +237,16 @@ MY_NAME=$(twitter whoami --json | jq -r '.data.user.username')
 twitter followers "$MY_NAME" --max 200 --json | jq -r '.data[].username' | grep -q "targetuser" && echo "Yes" || echo "No"
 ```
 
+### Read and summarize a Twitter Article
+
+```bash
+# Fetch article as JSON and extract title + body for LLM summarization
+twitter article 1234567890 --json | jq '{title: .data.articleTitle, body: .data.articleText}'
+
+# Or use compact mode — note: compact truncates text, prefer --json for full article body
+twitter article https://x.com/user/article/1234567890 --json
+```
+
 ### Daily reading workflow
 
 ```bash
@@ -288,6 +301,7 @@ twitter bookmarks --filter
 - **No polls** — can't create polls
 - **Single account** — one set of credentials at a time
 - **Likes are private** — Twitter/X made all likes private since June 2024. `twitter likes` only works for your own account
+- **Articles read-only** — `twitter article` can read Articles but cannot create or edit them
 
 ## Safety Notes
 

--- a/twitter_cli/cli.py
+++ b/twitter_cli/cli.py
@@ -9,6 +9,7 @@ Read commands:
     twitter user-posts elonmusk       # user tweets
     twitter likes elonmusk            # user likes
     twitter tweet <id>                # tweet detail + replies
+    twitter article <id>              # Twitter Article (long-form)
     twitter list <id>                 # list timeline
     twitter followers <handle>        # followers list
     twitter following <handle>        # following list
@@ -45,6 +46,7 @@ from .client import TwitterClient
 from .config import load_config
 from .filter import filter_tweets
 from .formatter import (
+    print_article,
     print_filter_stats,
     print_tweet_detail,
     print_tweet_table,
@@ -62,6 +64,7 @@ from .output import (
     use_rich_output,
 )
 from .serialization import (
+    tweet_to_dict,
     tweets_from_json,
     tweets_to_data,
     tweets_to_compact_json,
@@ -209,7 +212,8 @@ def _normalize_tweet_id(value):
     candidate = raw
     if parsed.scheme and parsed.netloc:
         path = parsed.path.rstrip("/")
-        match = re.search(r"/status/(\d+)$", path)
+        # Matches both /status/<id> (tweets) and /article/<id> (Twitter Articles)
+        match = re.search(r"/(?:status|article)/(\d+)$", path)
         if not match:
             raise RuntimeError("Invalid tweet URL: %s" % value)
         candidate = match.group(1)
@@ -619,6 +623,44 @@ def tweet(ctx, tweet_id, max_count, as_json, as_yaml):
         if len(tweets) > 1:
             console.print("\n💬 Replies:")
             print_tweet_table(tweets[1:], console, title="💬 Replies — %d" % (len(tweets) - 1))
+    console.print()
+
+
+@cli.command(name="article")
+@click.argument("tweet_id")
+@structured_output_options
+@click.pass_context
+def article(ctx, tweet_id, as_json, as_yaml):
+    # type: (Any, str, bool, bool) -> None
+    """Fetch and display a Twitter Article. TWEET_ID is the numeric tweet ID or full URL.
+
+    Twitter Articles are long-form posts (distinct from regular tweets).
+    The article body is rendered as Markdown in the terminal.
+    """
+    compact = ctx.obj.get("compact", False)
+    tweet_id = _normalize_tweet_id(tweet_id)
+    config = load_config()
+    rich_output = use_rich_output(as_json=as_json, as_yaml=as_yaml, compact=compact)
+    try:
+        client = _get_client_for_output(config, quiet=not rich_output)
+        if rich_output:
+            console.print("📰 Fetching article %s...\n" % tweet_id)
+        start = time.time()
+        art = client.fetch_article(tweet_id)
+        elapsed = time.time() - start
+        if rich_output:
+            console.print("✅ Fetched in %.1fs\n" % elapsed)
+    except RuntimeError as exc:
+        _exit_with_error(exc)
+
+    if compact:
+        click.echo(tweets_to_compact_json([art]))
+        return
+
+    if emit_structured(tweet_to_dict(art), as_json=as_json, as_yaml=as_yaml):
+        return
+
+    print_article(art, console)
     console.print()
 
 

--- a/twitter_cli/client.py
+++ b/twitter_cli/client.py
@@ -321,6 +321,55 @@ class TwitterClient:
             },
         )
 
+    def fetch_article(self, tweet_id):
+        # type: (str) -> Tweet
+        """Fetch a Twitter Article by its tweet ID and return parsed content.
+
+        Uses TweetResultByRestId instead of TweetDetail because we only want
+        the article itself — TweetDetail would also fetch the replies timeline,
+        adding unnecessary data and parsing overhead.
+
+        withArticlePlainText=True is the key flag: without it the API omits the
+        article body from the response even when withArticleRichContentState=True.
+        The actual draft.js-to-Markdown conversion happens in _parse_article().
+        """
+        logger.debug("fetch_article: tweet_id=%s", tweet_id)
+
+        data = self._graphql_get(
+            "TweetResultByRestId",
+            variables={
+                "tweetId": tweet_id,
+                "withCommunity": False,
+                "includePromotedContent": False,
+                "withVoice": False,
+            },
+            features={
+                "longform_notetweets_consumption_enabled": True,
+                "responsive_web_twitter_article_tweet_consumption_enabled": True,
+                "longform_notetweets_rich_text_read_enabled": True,
+                "longform_notetweets_inline_media_enabled": True,
+                "articles_preview_enabled": True,
+                "responsive_web_graphql_exclude_directive_enabled": True,
+                "verified_phone_label_enabled": False,
+            },
+            field_toggles={
+                "withArticleRichContentState": True,
+                "withArticlePlainText": True,  # must be True — omitting returns no article body
+            },
+        )
+
+        # TweetResultByRestId returns a single result at data.tweetResult.result
+        result = _deep_get(data, "data", "tweetResult", "result")
+        if not result:
+            raise NotFoundError("Article not found: tweet_id=%s" % tweet_id)
+
+        tweet = parse_tweet_result(result)
+        if tweet is None or tweet.article_title is None:
+            raise NotFoundError("Tweet %s has no article content" % tweet_id)
+
+        logger.info("fetch_article: '%s' (tweet_id=%s)", tweet.article_title, tweet_id)
+        return tweet
+
     def fetch_list_timeline(self, list_id, count=20):
         # type: (str, int) -> List[Tweet]
         """Fetch tweets from a Twitter List."""

--- a/twitter_cli/formatter.py
+++ b/twitter_cli/formatter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
@@ -145,6 +146,47 @@ def print_tweet_detail(tweet: Tweet, console: Optional[Console] = None) -> None:
         border_style="blue",
         expand=True,
     ))
+
+
+def print_article(tweet: Tweet, console: Optional[Console] = None) -> None:
+    """Print a Twitter Article with rich formatting.
+
+    Shows a header Panel (author, date, URL, stats) followed by the article
+    body rendered as Markdown. Separating body from Panel avoids line-length
+    constraints that a Panel would impose on long prose.
+    """
+    if console is None:
+        console = Console()
+
+    verified = " ✓" if tweet.author.verified else ""
+    title = tweet.article_title or "Article"
+
+    # Meta panel: author, link, engagement stats
+    meta_parts = [
+        "By @%s%s (%s)" % (tweet.author.screen_name, verified, tweet.author.name),
+        "🕐 %s" % tweet.created_at,
+        "🔗 x.com/%s/status/%s" % (tweet.author.screen_name, tweet.id),
+        "",
+        "❤️ %s  🔄 %s  💬 %s  🔖 %s  👁️ %s"
+        % (
+            format_number(tweet.metrics.likes),
+            format_number(tweet.metrics.retweets),
+            format_number(tweet.metrics.replies),
+            format_number(tweet.metrics.bookmarks),
+            format_number(tweet.metrics.views),
+        ),
+    ]
+    console.print(Panel(
+        "\n".join(meta_parts),
+        title="📰 %s" % title,
+        border_style="blue",
+        expand=True,
+    ))
+
+    # Render article body as Markdown if present
+    if tweet.article_text:
+        console.print()
+        console.print(Markdown(tweet.article_text))
 
 
 def print_filter_stats(

--- a/twitter_cli/graphql.py
+++ b/twitter_cli/graphql.py
@@ -43,6 +43,10 @@ FALLBACK_QUERY_IDS = {
     "DeleteRetweet": "iQtK4dl5hBmXewYZuEOKVw",
     "CreateBookmark": "aoDbu3RHznuiSkQ9aNM67Q",
     "DeleteBookmark": "Wlmlj2-xISYCixDmuS8KNg",
+    # Single-tweet fetch — used by fetch_article to get just the article tweet
+    # without the replies timeline that TweetDetail returns.
+    # queryId sourced from the community twitter-openapi spec.
+    "TweetResultByRestId": "7xflPyRiUxGVbJd4uWmbfg",
 }
 
 # ── Default feature flags ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `twitter article <id|url>` command to fetch and display Twitter Articles (long-form posts, distinct from regular tweets)
- Article body is retrieved via the `TweetResultByRestId` GraphQL endpoint (lighter than `TweetDetail` — no replies timeline) with the `withArticlePlainText=True` field toggle, which is required for the API to include the article body
- Draft.js content blocks are converted to Markdown by `_parse_article()` in `parser.py`, then rendered in the terminal using `rich.Markdown`
- Accepts both numeric IDs and full URLs (`/article/<id>` and `/status/<id>` patterns both supported)
- Supports `--json`, `--yaml`, and `--compact` output modes consistently with all other read commands
- `articleTitle` and `articleText` fields are included in the standard tweet JSON/YAML output envelope

## Files changed

| File | Change |
|------|--------|
| `twitter_cli/graphql.py` | Add `TweetResultByRestId` queryId |
| `twitter_cli/client.py` | Add `fetch_article()` method |
| `twitter_cli/formatter.py` | Add `print_article()` with rich Panel + Markdown rendering |
| `twitter_cli/cli.py` | Add `article` command; extend URL regex to accept `/article/` paths |
| `README.md` | Document new command in Features + Usage (EN + ZH) |
| `SCHEMA.md` | Document `articleTitle` / `articleText` output fields |
| `SKILL.md` | Add to Command Reference, agent workflow example, Limitations |

## Test plan

- [ ] `twitter article <numeric-id>` fetches and renders a known article
- [ ] `twitter article <full-article-url>` (e.g. `https://x.com/user/article/123`) resolves correctly
- [ ] `twitter article <id> --json` returns envelope with `articleTitle` and `articleText` under `data`
- [ ] `twitter article <regular-tweet-id>` returns a clear `not_found` error (tweet has no article content)
- [ ] `twitter article --help` shows correct usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)