### PR TITLE
feat: add --update self-update command and logic

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -656,27 +656,38 @@ def test_update_already_up_to_date(monkeypatch) -> None:
     assert "up to date" in result.output
 
 
-def test_update_triggers_upgrade_windows(monkeypatch) -> None:
+def test_update_triggers_upgrade_windows(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("twitter_cli.cli.__version__", "1.0.0")
     monkeypatch.setattr("twitter_cli.cli._fetch_latest_version", lambda pkg: "1.1.0")
     monkeypatch.setattr("twitter_cli.cli._detect_package_manager", lambda: "uv")
     monkeypatch.setattr("sys.platform", "win32")
 
-    calls = []
+    popen_calls = []
 
-    class FakeCompleted:
-        returncode = 0
+    class FakePopen:
+        def __init__(self, cmd, **kw):
+            popen_calls.append(cmd)
 
-    monkeypatch.setattr("twitter_cli.cli._win32_run_unlocked", lambda cmd: calls.append(cmd))
-    monkeypatch.setattr("subprocess.run", lambda cmd, **kw: calls.append(cmd) or FakeCompleted())
+    # Redirect bat to tmp_path so mkstemp doesn't touch the real filesystem
+    import os
+
+    def fake_mkstemp(suffix=""):
+        path = str(tmp_path / ("upgrade" + suffix))
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+        return fd, path
+
+    monkeypatch.setattr("tempfile.mkstemp", fake_mkstemp)
+    monkeypatch.setattr("subprocess.Popen", FakePopen)
 
     result = CliRunner().invoke(cli, ["--update"])
 
     assert result.exit_code == 0
-    assert calls == [["uv", "tool", "upgrade", "twitter-cli"]]
+    assert len(popen_calls) == 1
+    assert popen_calls[0][0] == "cmd.exe"
+    assert popen_calls[0][1] == "/c"
     assert "1.0.0" in result.output
     assert "1.1.0" in result.output
-    assert "up to date" in result.output
+    assert "reopen" in result.output
 
 
 def test_update_triggers_upgrade_unix(monkeypatch) -> None:
@@ -710,6 +721,24 @@ def test_update_pypi_failure(monkeypatch) -> None:
 
     assert result.exit_code != 0
     assert "Failed to fetch" in result.output
+
+
+def test_update_command_fails_nonzero(monkeypatch) -> None:
+    monkeypatch.setattr("twitter_cli.cli.__version__", "1.0.0")
+    monkeypatch.setattr("twitter_cli.cli._fetch_latest_version", lambda pkg: "2.0.0")
+    monkeypatch.setattr("twitter_cli.cli._detect_package_manager", lambda: "uv")
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda cmd, **kw: (_ for _ in ()).throw(
+            __import__("subprocess").CalledProcessError(2, cmd)
+        ),
+    )
+
+    result = CliRunner().invoke(cli, ["--update"])
+
+    assert result.exit_code == 2
+    assert "Update failed" in result.output
 
 
 def test_update_command_not_found(monkeypatch) -> None:
@@ -769,13 +798,7 @@ def test_build_update_cmd_pipx() -> None:
     assert _build_update_cmd("pipx", "twitter-cli") == ["pipx", "upgrade", "twitter-cli"]
 
 
-def test_build_update_cmd_pip_bin(monkeypatch) -> None:
-    monkeypatch.setattr("shutil.which", lambda x: "/usr/bin/pip" if x == "pip" else None)
-    assert _build_update_cmd("pip", "twitter-cli") == ["/usr/bin/pip", "install", "--upgrade", "twitter-cli"]
-
-
-def test_build_update_cmd_pip_fallback_python(monkeypatch) -> None:
-    monkeypatch.setattr("shutil.which", lambda x: None)
+def test_build_update_cmd_pip(monkeypatch) -> None:
     import sys
     cmd = _build_update_cmd("pip", "twitter-cli")
     assert cmd == [sys.executable, "-m", "pip", "install", "--upgrade", "twitter-cli"]

--- a/twitter_cli/cli.py
+++ b/twitter_cli/cli.py
@@ -332,15 +332,18 @@ def _detect_package_manager():
 
 
 def _build_update_cmd(manager, pkg):
-    import shutil
     if manager == "uv":
         return ["uv", "tool", "upgrade", pkg]
     if manager == "pipx":
         return ["pipx", "upgrade", pkg]
-    pip_bin = shutil.which("pip") or shutil.which("pip3")
-    if pip_bin:
-        return [str(pip_bin), "install", "--upgrade", pkg]
     return [sys.executable, "-m", "pip", "install", "--upgrade", pkg]
+
+
+def _version_tuple(v: str):
+    try:
+        return tuple(int(x) for x in v.split(".")[:3])
+    except ValueError:
+        return (0,)
 
 
 def _fetch_latest_version(pkg):
@@ -351,26 +354,32 @@ def _fetch_latest_version(pkg):
         return json.loads(resp.read())["info"]["version"]
 
 
-def _win32_run_unlocked(cmd):
-    import shutil
-    launcher_str = shutil.which("twitter")
-    launcher = Path(str(launcher_str)) if launcher_str else Path(sys.executable).parent / "twitter.exe"
-    stale = launcher.with_suffix(".old.exe")
-    if launcher.exists():
-        try:
-            if stale.exists():
-                stale.unlink(missing_ok=True)
-            launcher.rename(stale)
-        except OSError:
-            pass
-    try:
-        subprocess.run(cmd, check=True)
-    finally:
-        if not launcher.exists() and stale.exists():
-            try:
-                stale.rename(launcher)
-            except OSError:
-                pass
+def _win32_spawn_upgrade(cmd):
+    """On Windows the running twitter.exe is file-locked, so we can't upgrade it
+    in-process.  Instead write a tiny batch script that waits for our PID to
+    exit (releasing the lock) and then runs the upgrade command detached."""
+    import os
+    import tempfile
+
+    pid = os.getpid()
+    # Poll until our PID disappears, then run the upgrade and self-delete.
+    bat_lines = [
+        "@echo off",
+        ":wait",
+        f'tasklist /fi "PID eq {pid}" 2>nul | find /i "{pid}" >nul',
+        "if not errorlevel 1 (ping -n 2 127.0.0.1 >nul & goto wait)",
+        " ".join(f'"{c}"' for c in cmd),
+        'del "%~f0"',
+    ]
+    fd, bat_path = tempfile.mkstemp(suffix=".bat")
+    with os.fdopen(fd, "w") as f:
+        f.write("\r\n".join(bat_lines) + "\r\n")
+    DETACHED_PROCESS = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+    CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+    subprocess.Popen(
+        ["cmd.exe", "/c", bat_path],
+        creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP,
+    )
 
 
 def _do_update(ctx, _param, value):
@@ -385,18 +394,20 @@ def _do_update(ctx, _param, value):
     except Exception:
         console.print("[red]Failed to fetch latest version from PyPI.[/red]")
         sys.exit(1)
-    if current == latest:
+    if _version_tuple(current) >= _version_tuple(latest):
         console.print("twitter-cli is up to date (%s)" % current)
         ctx.exit()
         return
     manager = _detect_package_manager()
     cmd = _build_update_cmd(manager, pkg)
     console.print("Updating %s -> %s via %s..." % (current, latest, manager))
+    if sys.platform == "win32":
+        _win32_spawn_upgrade(cmd)
+        console.print("Upgrade launched — reopen your terminal once it completes.")
+        ctx.exit()
+        return
     try:
-        if sys.platform == "win32":
-            _win32_run_unlocked(cmd)
-        else:
-            subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True)
     except FileNotFoundError:
         console.print("[red]Command not found: %s[/red]" % cmd[0])
         sys.exit(1)


### PR DESCRIPTION
Implement a self-update feature for twitter-cli: add a new --update click option and the update callback _do_update. Introduce helper functions _detect_package_manager, _build_update_cmd, _fetch_latest_version and a Windows-safe runner _win32_run_unlocked; import subprocess where needed. The update flow checks PyPI for the latest version, determines the appropriate package manager (uv, pipx or pip), builds the upgrade command, and runs it with error handling for command-not-found and process failures. Add comprehensive tests covering up-to-date behavior, upgrade invocation on Windows and Unix, PyPI failure, command-not-found handling, package manager detection fallbacks, and command building.