### PR TITLE
Add Explore news commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A terminal-first CLI for Twitter/X: read timelines, bookmarks, and user profiles
 - Timeline: fetch `for-you` and `following` feeds
 - Bookmarks: list saved tweets from your account
 - Search: find tweets by keyword with Top/Latest/Photos/Videos tabs
+- Explore: fetch Explore tabs such as News, Trending, Sports, and Entertainment
 - Tweet detail: view a tweet and its replies; use `show <N>` to open tweet #N from the last list output
 - Article: fetch a Twitter Article and export it as Markdown
 - List timeline: fetch tweets from a Twitter List
@@ -117,6 +118,11 @@ twitter search "python" --from elonmusk --lang en --since 2026-01-01
 twitter search --from bbc --exclude retweets --has links
 twitter search "topic" -o results.json         # Save to file
 twitter search "trending" --filter              # Apply ranking filter
+
+# Explore / today news
+twitter explore --section news --json
+twitter explore --section trending --max 20
+twitter today-news --json
 
 # Tweet detail (view tweet + replies)
 twitter tweet 1234567890
@@ -377,6 +383,7 @@ git clone git@github.com:jackwener/twitter-cli.git .agents/skills/twitter-cli
 - 时间线读取：支持 `for-you` 和 `following`
 - 收藏读取：查看账号书签推文
 - 搜索：按关键词搜索推文，支持 Top/Latest/Photos/Videos
+- Explore：获取 News、Trending、Sports、Entertainment 等探索页条目
 - 推文详情：查看推文及其回复；用 `show <N>` 可直接打开上次列表里的第 N 条推文
 - 文章读取：获取 Twitter 长文，并导出为 Markdown
 - 列表时间线：获取 Twitter List 的推文
@@ -440,6 +447,11 @@ twitter search "AI agent" -t Latest --max 50
 twitter search "AI agent" --full-text
 twitter search "topic" -o results.json         # 保存到文件
 twitter search "trending" --filter              # 启用排序筛选
+
+# 探索 / 今日新闻
+twitter explore --section news --json
+twitter explore --section trending --max 20
+twitter today-news --json
 
 # 推文详情
 twitter tweet 1234567890

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -27,6 +27,7 @@ error:
 - `--yaml` and `--json` both use this envelope
 - non-TTY stdout defaults to YAML
 - tweet and user lists are returned under `data`
+- Explore commands return trend/news item lists under `data`
 - timeline-style list commands may also return `pagination.nextCursor`
 - `article` returns a single tweet object under `data`
 - `status` returns `data.authenticated` plus `data.user`
@@ -44,6 +45,25 @@ data:
   articleText: |
     # Heading
     Body text...
+```
+
+## Explore Fields
+
+`twitter explore --section news --json` and `twitter today-news --json` return Explore
+items:
+
+```yaml
+data:
+  - id: "1234567890"
+    name: "Topic title"
+    section: news
+    context: "4 hours ago · News · 195 posts"
+    category: News
+    timeContext: "4 hours ago"
+    postCountText: "195 posts"
+    url: "twitter://trending/1234567890"
+    imageUrls: []
+    isAiTrend: false
 ```
 
 ## Error Codes

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ import yaml
 
 from twitter_cli.cli import cli
 from twitter_cli.formatter import article_to_markdown, print_tweet_table
-from twitter_cli.models import Author, BookmarkFolder, Metrics, Tweet, UserProfile
+from twitter_cli.models import Author, BookmarkFolder, ExploreItem, Metrics, Tweet, UserProfile
 from twitter_cli.serialization import tweets_to_json
 
 
@@ -704,6 +704,79 @@ def test_cli_search_empty_query_no_options() -> None:
     result = runner.invoke(cli, ["search"])
     assert result.exit_code != 0
     assert "Provide a QUERY" in result.output
+
+
+def test_cli_explore_news_json(monkeypatch) -> None:
+    captured = {}
+
+    class FakeClient:
+        def fetch_explore_timeline(
+            self,
+            section: str,
+            count: int,
+            cursor: str | None = None,
+            return_cursor: bool = False,
+        ):
+            captured["section"] = section
+            captured["count"] = count
+            captured["cursor"] = cursor
+            captured["return_cursor"] = return_cursor
+            return [
+                ExploreItem(
+                    id="123",
+                    name="OpenAI launches feature",
+                    section=section,
+                    context="4 hours ago · News · 195 posts",
+                    category="News",
+                    time_context="4 hours ago",
+                    post_count_text="195 posts",
+                    url="twitter://trending/123",
+                    is_ai_trend=True,
+                )
+            ], "cursor-next"
+
+    monkeypatch.setattr("twitter_cli.cli._get_client", lambda config=None, quiet=False: FakeClient())
+    monkeypatch.setattr(
+        "twitter_cli.cli.load_config",
+        lambda: {"fetch": {"count": 20}, "filter": {}, "rateLimit": {}},
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["explore", "--section", "news", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert captured == {
+        "section": "news",
+        "count": 20,
+        "cursor": None,
+        "return_cursor": True,
+    }
+    assert payload["ok"] is True
+    assert payload["data"][0]["name"] == "OpenAI launches feature"
+    assert payload["data"][0]["isAiTrend"] is True
+    assert payload["pagination"]["nextCursor"] == "cursor-next"
+
+
+def test_cli_today_news_alias_uses_news_section(monkeypatch) -> None:
+    captured = {}
+
+    class FakeClient:
+        def fetch_explore_timeline(self, section: str, count: int, cursor=None, return_cursor=False):
+            captured["section"] = section
+            return [], None
+
+    monkeypatch.setattr("twitter_cli.cli._get_client", lambda config=None, quiet=False: FakeClient())
+    monkeypatch.setattr(
+        "twitter_cli.cli.load_config",
+        lambda: {"fetch": {"count": 10}, "filter": {}, "rateLimit": {}},
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["today-news", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["section"] == "news"
 
 
 def test_cli_search_invalid_date_rejected(monkeypatch) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1434,3 +1434,85 @@ class TestFetchSearchUsesPost:
 
         assert captured.get("product") == "Latest"
         assert captured.get("querySource") == "typed_query"
+
+
+# ── fetch_explore_timeline ────────────────────────────────────────────────
+
+class TestFetchExploreTimeline:
+    """Verify Explore tab lookup and timeline parsing."""
+
+    def _make_client(self):
+        client = TwitterClient.__new__(TwitterClient)
+        client._auth_token = "tok"
+        client._ct0 = "ct0"
+        client._cookie_string = None
+        client._request_delay = 0
+        client._max_retries = 0
+        client._retry_base_delay = 0
+        client._max_count = 200
+        client._client_transaction = None
+        client._ct_init_attempted = True
+        return client
+
+    def test_fetch_explore_timeline_resolves_section_timeline_id(self):
+        client = self._make_client()
+        calls = []
+
+        def mock_get(operation_name, variables, features, field_toggles=None):
+            calls.append((operation_name, variables))
+            if operation_name == "ExplorePage":
+                return {
+                    "data": {
+                        "explore_page": {
+                            "body": {
+                                "timelines": [
+                                    {"id": "news", "timeline": {"id": "encoded-news"}},
+                                ]
+                            }
+                        }
+                    }
+                }
+            if operation_name == "GenericTimelineById":
+                assert variables["timelineId"] == "encoded-news"
+                return {
+                    "data": {
+                        "timeline": {
+                            "timeline": {
+                                "instructions": [
+                                    {
+                                        "entries": [
+                                            {
+                                                "content": {
+                                                    "entryType": "TimelineTimelineItem",
+                                                    "itemContent": {
+                                                        "__typename": "TimelineTrend",
+                                                        "itemType": "TimelineTrend",
+                                                        "name": "Launch news",
+                                                        "social_context": {
+                                                            "text": "1 hour ago · News · 10 posts",
+                                                        },
+                                                        "trend_url": {
+                                                            "url": "twitter://trending/555",
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            return {}
+
+        client._graphql_get = mock_get
+
+        items, cursor = client.fetch_explore_timeline("news", count=5, return_cursor=True)
+
+        assert [call[0] for call in calls] == ["ExplorePage", "GenericTimelineById"]
+        assert cursor is None
+        assert len(items) == 1
+        assert items[0].id == "555"
+        assert items[0].name == "Launch news"
+        assert items[0].section == "news"

--- a/tests/test_parser_fixtures.py
+++ b/tests/test_parser_fixtures.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from twitter_cli.client import TwitterClient
-from twitter_cli.parser import _deep_get, parse_timeline_response
+from twitter_cli.parser import _deep_get, parse_explore_timeline_response, parse_timeline_response
 
 
 def _make_client() -> TwitterClient:
@@ -75,6 +75,72 @@ def test_parse_search_timeline_fixture_with_module_items(fixture_loader) -> None
     assert cursor == "search-cursor"
     assert tweets[0].media[0].type == "video"
     assert tweets[0].media[0].url == "https://video-high.mp4"
+
+
+def test_parse_explore_timeline_trends_from_module_items() -> None:
+    payload = {
+        "data": {
+            "timeline": {
+                "timeline": {
+                    "instructions": [
+                        {
+                            "entries": [
+                                {
+                                    "content": {
+                                        "entryType": "TimelineTimelineModule",
+                                        "items": [
+                                            {
+                                                "entryId": "trend-1",
+                                                "item": {
+                                                    "itemContent": {
+                                                        "__typename": "TimelineTrend",
+                                                        "itemType": "TimelineTrend",
+                                                        "name": "OpenAI launches feature",
+                                                        "is_ai_trend": True,
+                                                        "social_context": {
+                                                            "text": "4 hours ago · News · 195 posts",
+                                                            "contextImageUrls": ["https://example.com/a.jpg"],
+                                                        },
+                                                        "trend_url": {
+                                                            "url": "twitter://trending/12345",
+                                                            "urlType": "DeepLink",
+                                                        },
+                                                    }
+                                                },
+                                            }
+                                        ],
+                                    }
+                                },
+                                {
+                                    "content": {
+                                        "entryType": "TimelineTimelineCursor",
+                                        "cursorType": "Bottom",
+                                        "value": "cursor-next",
+                                    }
+                                },
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    items, cursor = parse_explore_timeline_response(
+        payload,
+        lambda data: _deep_get(data, "data", "timeline", "timeline", "instructions"),
+        section="news",
+    )
+
+    assert cursor == "cursor-next"
+    assert len(items) == 1
+    assert items[0].id == "12345"
+    assert items[0].name == "OpenAI launches feature"
+    assert items[0].section == "news"
+    assert items[0].category == "News"
+    assert items[0].time_context == "4 hours ago"
+    assert items[0].post_count_text == "195 posts"
+    assert items[0].is_ai_trend is True
 
 
 def test_parse_list_timeline_fixture_with_visibility_wrapper(fixture_loader) -> None:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from twitter_cli.serialization import tweet_from_dict, tweet_to_dict, tweets_from_json, tweets_to_json
+from twitter_cli.models import ExploreItem
+from twitter_cli.serialization import (
+    explore_item_to_dict,
+    tweet_from_dict,
+    tweet_to_dict,
+    tweets_from_json,
+    tweets_to_json,
+)
 
 
 def test_tweet_roundtrip_dict(tweet_factory) -> None:
@@ -93,3 +100,27 @@ def test_tweet_roundtrip_preserves_promoted_flag(tweet_factory) -> None:
     assert payload["isPromoted"] is True
     restored = tweet_from_dict(payload)
     assert restored.is_promoted is True
+
+
+def test_explore_item_serialization() -> None:
+    item = ExploreItem(
+        id="123",
+        name="OpenAI launches feature",
+        section="news",
+        context="4 hours ago · News · 195 posts",
+        category="News",
+        time_context="4 hours ago",
+        post_count_text="195 posts",
+        url="twitter://trending/123",
+        image_urls=["https://example.com/a.jpg"],
+        is_ai_trend=True,
+    )
+
+    payload = explore_item_to_dict(item)
+
+    assert payload["id"] == "123"
+    assert payload["name"] == "OpenAI launches feature"
+    assert payload["section"] == "news"
+    assert payload["postCountText"] == "195 posts"
+    assert payload["imageUrls"] == ["https://example.com/a.jpg"]
+    assert payload["isAiTrend"] is True

--- a/twitter_cli/cli.py
+++ b/twitter_cli/cli.py
@@ -8,6 +8,8 @@ Read commands:
     twitter bookmarks folders <id>    # tweets in a folder
     twitter search "query"            # search tweets
     twitter search "query" --from user  # advanced search
+    twitter explore --section news    # Explore trends/news
+    twitter today-news                # Explore News shortcut
     twitter user elonmusk             # user profile
     twitter user-posts elonmusk       # user tweets
     twitter likes elonmusk            # user likes
@@ -54,6 +56,7 @@ from .config import load_config
 from .filter import filter_tweets
 from .formatter import (
     article_to_markdown,
+    print_explore_table,
     print_filter_stats,
     print_article,
     print_tweet_detail,
@@ -73,6 +76,8 @@ from .output import (
     use_rich_output,
 )
 from .serialization import (
+    explore_items_to_data,
+    explore_items_to_json,
     tweet_to_dict,
     tweets_from_json,
     tweets_to_data,
@@ -96,6 +101,7 @@ FEED_TYPES = ["for-you", "following"]
 SEARCH_PRODUCTS = ["Top", "Latest", "Photos", "Videos"]
 SEARCH_HAS_CHOICES = ["links", "images", "videos", "media"]
 SEARCH_EXCLUDE_CHOICES = ["retweets", "replies", "links"]
+EXPLORE_SECTIONS = ["for-you", "trending", "news", "sports", "entertainment"]
 
 
 def _agent_user_profile(profile: UserProfile) -> dict:
@@ -353,6 +359,15 @@ def _emit_timeline_structured(tweets, next_cursor, *, as_json, as_yaml):
     # type: (TweetList, Optional[str], bool, bool) -> bool
     """Emit timeline data with pagination metadata while keeping `data` a tweet list."""
     payload = success_payload(tweets_to_data(tweets))
+    if next_cursor:
+        payload["pagination"] = {"nextCursor": next_cursor}
+    return emit_structured(payload, as_json=as_json, as_yaml=as_yaml)
+
+
+def _emit_explore_structured(items, next_cursor, *, as_json, as_yaml):
+    # type: (Any, Optional[str], bool, bool) -> bool
+    """Emit Explore data with pagination metadata while keeping `data` an item list."""
+    payload = success_payload(explore_items_to_data(items))
     if next_cursor:
         payload["pagination"] = {"nextCursor": next_cursor}
     return emit_structured(payload, as_json=as_json, as_yaml=as_yaml)
@@ -795,6 +810,99 @@ def search(ctx, query, product, from_user, to_user, lang, since, until, has, exc
             compact=compact, full_text=full_text,
         )
     _run_guarded(_run)
+
+
+def _run_explore_command(ctx, section, max_count, cursor, as_json, as_yaml, output_file):
+    # type: (Any, str, Optional[int], Optional[str], bool, bool, Optional[str]) -> None
+    compact = ctx.obj.get("compact", False)
+    config = load_config()
+    rich_output = use_rich_output(as_json=as_json, as_yaml=as_yaml, compact=compact)
+    next_cursor = None  # type: Optional[str]
+
+    def _run():
+        nonlocal next_cursor
+        fetch_count = _resolve_configured_count(config, max_count)
+        client = _get_client(config, quiet=not rich_output)
+        if rich_output:
+            console.print("Fetching Explore %s (%d items)...\n" % (section, fetch_count))
+        start = time.time()
+        items, next_cursor = client.fetch_explore_timeline(
+            section,
+            fetch_count,
+            cursor=cursor,
+            return_cursor=True,
+        )
+        elapsed = time.time() - start
+        if rich_output:
+            console.print("Fetched %d Explore %s items in %.1fs\n" % (len(items), section, elapsed))
+        return items
+
+    try:
+        items = _run()
+    except (TwitterError, RuntimeError) as exc:
+        _exit_with_error(exc)
+
+    if output_file:
+        Path(output_file).write_text(explore_items_to_json(items), encoding="utf-8")
+        if rich_output:
+            console.print("Saved Explore items to %s\n" % output_file)
+
+    if compact:
+        click.echo(explore_items_to_json(items))
+        return
+
+    if _emit_explore_structured(items, next_cursor, as_json=as_json, as_yaml=as_yaml):
+        return
+
+    print_explore_table(
+        items,
+        console,
+        title="Explore %s - %d items" % (section, len(items)),
+    )
+    console.print()
+
+
+@cli.command()
+@click.option(
+    "--section",
+    "-s",
+    type=click.Choice(EXPLORE_SECTIONS),
+    default="news",
+    help="Explore section: for-you, trending, news, sports, or entertainment.",
+)
+@click.option("--max", "-n", "max_count", type=int, default=None, help="Max number of items to fetch.")
+@click.option("--cursor", type=str, default=None, help="Pagination cursor for continuing a previous Explore request.")
+@structured_output_options
+@click.option("--output", "-o", "output_file", type=str, default=None, help="Save Explore items to JSON file.")
+@click.pass_context
+def explore(ctx, section, max_count, cursor, as_json, as_yaml, output_file):
+    # type: (Any, str, Optional[int], Optional[str], bool, bool, Optional[str]) -> None
+    """Fetch Explore trends/news from Twitter/X."""
+    _run_explore_command(ctx, section, max_count, cursor, as_json, as_yaml, output_file)
+
+
+@cli.command("today-news")
+@click.option("--max", "-n", "max_count", type=int, default=None, help="Max number of news items to fetch.")
+@click.option("--cursor", type=str, default=None, help="Pagination cursor for continuing a previous news request.")
+@structured_output_options
+@click.option("--output", "-o", "output_file", type=str, default=None, help="Save news items to JSON file.")
+@click.pass_context
+def today_news(ctx, max_count, cursor, as_json, as_yaml, output_file):
+    # type: (Any, Optional[int], Optional[str], bool, bool, Optional[str]) -> None
+    """Fetch today's Explore news items."""
+    _run_explore_command(ctx, "news", max_count, cursor, as_json, as_yaml, output_file)
+
+
+@cli.command("todaynew", hidden=True)
+@click.option("--max", "-n", "max_count", type=int, default=None, help="Max number of news items to fetch.")
+@click.option("--cursor", type=str, default=None, help="Pagination cursor for continuing a previous news request.")
+@structured_output_options
+@click.option("--output", "-o", "output_file", type=str, default=None, help="Save news items to JSON file.")
+@click.pass_context
+def todaynew(ctx, max_count, cursor, as_json, as_yaml, output_file):
+    # type: (Any, Optional[int], Optional[str], bool, bool, Optional[str]) -> None
+    """Compatibility alias for today-news."""
+    _run_explore_command(ctx, "news", max_count, cursor, as_json, as_yaml, output_file)
 
 
 @cli.command()

--- a/twitter_cli/client.py
+++ b/twitter_cli/client.py
@@ -51,6 +51,7 @@ from .models import BookmarkFolder, UserProfile
 from .parser import (
     _deep_get,
     _parse_int,
+    parse_explore_timeline_response,
     parse_timeline_response,
     parse_tweet_result,
     parse_user_result,
@@ -59,12 +60,12 @@ from .parser import (
 if TYPE_CHECKING:
     from typing import Dict, List, Optional, Set, Tuple  # noqa: F401
 
-    from .models import Tweet  # noqa: F401
+    from .models import ExploreItem, Tweet  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
 # Shared curl_cffi session (single-threaded CLI)
-_cffi_session = None
+_cffi_session: Any = None
 
 TimelineInstructionGetter = Callable[[Any], Any]
 
@@ -361,6 +362,40 @@ class TwitterClient:
             },
             override_base_variables=True,
             use_post=True,
+        )
+
+    def fetch_explore_page(self):
+        # type: () -> Dict[str, Any]
+        """Fetch the Explore page metadata, including available timelines."""
+        return self._graphql_get("ExplorePage", {}, FEATURES)
+
+    def fetch_explore_timeline(self, section="news", count=20, cursor=None, return_cursor=False):
+        # type: (str, int, Optional[str], bool) -> Any
+        """Fetch an Explore tab timeline such as news, trending, or sports."""
+        section_id = section.strip().lower().replace("-", "_")
+        page = self.fetch_explore_page()
+        timelines = _deep_get(page, "data", "explore_page", "body", "timelines") or []
+        timeline_id = None  # type: Optional[str]
+
+        for timeline in timelines:
+            if not isinstance(timeline, dict):
+                continue
+            if timeline.get("id") == section_id:
+                timeline_id = _deep_get(timeline, "timeline", "id")
+                break
+
+        if not timeline_id:
+            raise NotFoundError("Explore section not found: %s" % section)
+
+        section_label = section_id.replace("_", "-")
+        return self._fetch_explore_items(
+            "GenericTimelineById",
+            {"timelineId": timeline_id},
+            section_label,
+            count,
+            lambda data: _deep_get(data, "data", "timeline", "timeline", "instructions"),
+            start_cursor=cursor,
+            return_cursor=return_cursor,
         )
 
     def fetch_tweet_detail(self, tweet_id, count=20):
@@ -812,6 +847,58 @@ class TwitterClient:
         if return_cursor:
             return tweets[:count], continuation_cursor
         return tweets[:count]
+
+    def _fetch_explore_items(self, operation_name, base_variables, section, count, get_instructions, start_cursor=None, return_cursor=False):
+        # type: (str, Dict[str, Any], str, int, Callable[[Any], Any], Optional[str], bool) -> Any
+        """Generic Explore timeline fetcher with pagination and deduplication."""
+        if count <= 0:
+            return ([], None) if return_cursor else []
+
+        count = min(count, self._max_count)
+        items = []  # type: List[ExploreItem]
+        seen_ids = set()  # type: Set[str]
+        cursor = start_cursor  # type: Optional[str]
+        continuation_cursor = None  # type: Optional[str]
+        attempts = 0
+        max_attempts = int(math.ceil(count / 20.0)) + 2
+
+        while len(items) < count and attempts < max_attempts:
+            attempts += 1
+            variables = dict(base_variables)
+            variables["count"] = min(count - len(items) + 5, 40)
+            if cursor:
+                variables["cursor"] = cursor
+
+            data = self._graphql_get(operation_name, variables, FEATURES)
+            new_items, next_cursor = parse_explore_timeline_response(
+                data,
+                get_instructions,
+                section=section,
+            )
+            for item in new_items:
+                key = item.id or item.name
+                if key and key not in seen_ids:
+                    seen_ids.add(key)
+                    items.append(item)
+
+            if not next_cursor:
+                continuation_cursor = None
+                break
+            if next_cursor == cursor:
+                logger.debug("Explore pagination stopped because cursor did not advance: %s", next_cursor)
+                continuation_cursor = None
+                break
+            continuation_cursor = next_cursor
+            cursor = next_cursor
+
+            if len(items) < count and self._request_delay > 0:
+                jitter = self._request_delay * random.uniform(0.7, 1.5)
+                logger.debug("Sleeping %.1fs between explore requests", jitter)
+                time.sleep(jitter)
+
+        if return_cursor:
+            return items[:count], continuation_cursor
+        return items[:count]
 
     def _fetch_user_list(self, operation_name, user_id, count, get_instructions):
         # type: (str, str, int, Callable[[Any], Any]) -> List[UserProfile]

--- a/twitter_cli/commands/__init__.py
+++ b/twitter_cli/commands/__init__.py
@@ -1,7 +1,7 @@
 """CLI command sub-modules for twitter-cli.
 
 Commands are split into three groups:
-  - read: feed, bookmarks, search, tweet, article, show, list, favorites
+  - read: feed, bookmarks, search, explore, today-news, tweet, article, show, list, favorites
   - write: post, reply, quote, delete, like/unlike, retweet/unretweet, bookmark/unbookmark
   - user: user, user-posts, likes, followers, following, whoami, status, follow/unfollow
 """

--- a/twitter_cli/formatter.py
+++ b/twitter_cli/formatter.py
@@ -10,7 +10,7 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
-from .models import Tweet, UserProfile
+from .models import ExploreItem, Tweet, UserProfile
 from .timeutil import format_local_time, format_relative_time
 
 
@@ -242,6 +242,49 @@ def print_filter_stats(
         console.print(
             "   Score range: %.1f ~ %.1f" % (bottom_score, top_score)
         )
+
+
+def print_explore_table(
+    items: List[ExploreItem],
+    console: Optional[Console] = None,
+    title: Optional[str] = None,
+) -> None:
+    """Print Explore trends/news as a rich table."""
+    if console is None:
+        console = _make_console()
+
+    if not title:
+        title = "Explore - %d items" % len(items)
+
+    table = Table(title=title, show_lines=True, expand=True)
+    table.add_column("#", style="dim", width=3, justify="right")
+    table.add_column("Section", style="cyan", width=14, no_wrap=True)
+    table.add_column("Topic", ratio=3)
+    table.add_column("Context", style="green", ratio=2)
+
+    for i, item in enumerate(items):
+        topic = item.name
+        if item.url:
+            topic += "\n%s" % item.url
+
+        context_parts = []
+        if item.context:
+            context_parts.append(item.context)
+        else:
+            for part in (item.time_context, item.category, item.post_count_text):
+                if part:
+                    context_parts.append(part)
+        if item.is_ai_trend:
+            context_parts.append("AI trend")
+
+        table.add_row(
+            str(i + 1),
+            item.section,
+            topic,
+            "\n".join(context_parts),
+        )
+
+    console.print(table)
 
 
 def print_user_profile(user: UserProfile, console: Optional[Console] = None) -> None:

--- a/twitter_cli/graphql.py
+++ b/twitter_cli/graphql.py
@@ -49,6 +49,8 @@ FALLBACK_QUERY_IDS = {
     "TweetResultByRestId": "zy39CwTyYhU-_0LP7dljjg",
     "BookmarkFoldersSlice": "i78YDd0Tza-dV4SYs58kRg",
     "BookmarkFolderTimeline": "hNY7X2xE2N7HVF6Qb_mu6w",
+    "ExplorePage": "natW-0sLlOif7doGb8m_rQ",
+    "GenericTimelineById": "Dv_o7vs8Oz4Fo0R5A4a84A",
 }
 
 # ── Default feature flags ────────────────────────────────────────────────

--- a/twitter_cli/models.py
+++ b/twitter_cli/models.py
@@ -57,6 +57,20 @@ class Tweet:
 
 
 @dataclass
+class ExploreItem:
+    id: str
+    name: str
+    section: str = ""
+    context: str = ""
+    category: str = ""
+    time_context: str = ""
+    post_count_text: str = ""
+    url: str = ""
+    image_urls: List[str] = field(default_factory=list)
+    is_ai_trend: bool = False
+
+
+@dataclass
 class BookmarkFolder:
     id: str
     name: str

--- a/twitter_cli/parser.py
+++ b/twitter_cli/parser.py
@@ -7,12 +7,13 @@ Converts raw GraphQL response JSON into domain model objects
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Optional, Tuple  # noqa: F401
 
-from .models import Author, Metrics, Tweet, TweetMedia, UserProfile
+from .models import Author, ExploreItem, Metrics, Tweet, TweetMedia, UserProfile
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,88 @@ def _extract_cursor(content):
     if content.get("cursorType") == "Bottom":
         return content.get("value")
     return None
+
+
+def _parse_context_parts(context):
+    # type: (str) -> Tuple[str, str, str]
+    """Split X Explore social context into time/category/post-count parts."""
+    parts = [part.strip() for part in context.split("·") if part.strip()]
+    time_context = parts[0] if parts else ""
+    category = ""
+    post_count_text = ""
+    if len(parts) >= 3:
+        category = parts[1]
+        post_count_text = parts[2]
+    elif len(parts) == 2:
+        post_count_text = parts[1] if "post" in parts[1].lower() else ""
+        category = "" if post_count_text else parts[1]
+    return time_context, category, post_count_text
+
+
+def _extract_trend_id(url):
+    # type: (str) -> str
+    """Extract a trend id from twitter://trending/<id> deep links."""
+    if not url:
+        return ""
+    match = re.search(r"/trending/([^/?#]+)", url)
+    if match:
+        return match.group(1)
+    match = re.search(r"trending[:/]+([^/?#]+)", url)
+    return match.group(1) if match else ""
+
+
+def _parse_explore_trend(item_content, section):
+    # type: (Dict[str, Any], str) -> Optional[ExploreItem]
+    """Parse a TimelineTrend item from Explore timelines."""
+    if not isinstance(item_content, dict):
+        return None
+    if item_content.get("__typename") != "TimelineTrend" and item_content.get("itemType") != "TimelineTrend":
+        return None
+
+    name = item_content.get("name") or ""
+    if not name:
+        return None
+
+    social_context = item_content.get("social_context") or {}
+    context = social_context.get("text") or ""
+    time_context, category, post_count_text = _parse_context_parts(context)
+    image_urls = social_context.get("contextImageUrls") or []
+    url = (
+        _deep_get(item_content, "trend_url", "url")
+        or _deep_get(item_content, "trend_metadata", "url", "url")
+        or ""
+    )
+    trend_id = _extract_trend_id(url)
+
+    return ExploreItem(
+        id=trend_id or name,
+        name=name,
+        section=section,
+        context=context,
+        category=category,
+        time_context=time_context,
+        post_count_text=post_count_text,
+        url=url,
+        image_urls=[str(image_url) for image_url in image_urls if image_url],
+        is_ai_trend=bool(item_content.get("is_ai_trend", False)),
+    )
+
+
+def _extract_explore_items_from_content(content, section):
+    # type: (Dict[str, Any], str) -> List[ExploreItem]
+    """Extract Explore items from a timeline entry content object."""
+    items = []  # type: List[ExploreItem]
+    item_content = content.get("itemContent") or {}
+    parsed = _parse_explore_trend(item_content, section)
+    if parsed:
+        items.append(parsed)
+
+    for nested_item in content.get("items", []):
+        nested_content = _deep_get(nested_item, "item", "itemContent") or nested_item.get("itemContent") or {}
+        parsed = _parse_explore_trend(nested_content, section)
+        if parsed:
+            items.append(parsed)
+    return items
 
 
 # ── Media / Author extraction ────────────────────────────────────────────
@@ -529,3 +612,24 @@ def parse_timeline_response(data, get_instructions):
                         tweets.append(tweet)
 
     return tweets, next_cursor
+
+
+def parse_explore_timeline_response(data, get_instructions, section=""):
+    # type: (Any, Callable[[Any], Any], str) -> Tuple[List[ExploreItem], Optional[str]]
+    """Parse an Explore timeline GraphQL response into ExploreItem objects."""
+    items = []  # type: List[ExploreItem]
+    next_cursor = None  # type: Optional[str]
+
+    instructions = get_instructions(data)
+    if not isinstance(instructions, list):
+        logger.warning("No explore timeline instructions found")
+        return items, next_cursor
+
+    for instruction in instructions:
+        entries = instruction.get("entries") or instruction.get("moduleItems") or []
+        for entry in entries:
+            content = entry.get("content", {})
+            next_cursor = _extract_cursor(content) or next_cursor
+            items.extend(_extract_explore_items_from_content(content, section))
+
+    return items, next_cursor

--- a/twitter_cli/serialization.py
+++ b/twitter_cli/serialization.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, Iterable, List, Optional
 
-from .models import Author, BookmarkFolder, Metrics, Tweet, TweetMedia, UserProfile
+from .models import Author, BookmarkFolder, ExploreItem, Metrics, Tweet, TweetMedia, UserProfile
 from .timeutil import format_iso8601, format_local_time
 
 
@@ -177,6 +177,32 @@ def tweets_to_compact_json(tweets: Iterable[Tweet]) -> str:
         ensure_ascii=False,
         indent=2,
     )
+
+
+def explore_item_to_dict(item: ExploreItem) -> Dict[str, Any]:
+    """Convert an ExploreItem dataclass into a JSON-safe dict."""
+    return {
+        "id": item.id,
+        "name": item.name,
+        "section": item.section,
+        "context": item.context,
+        "category": item.category,
+        "timeContext": item.time_context,
+        "postCountText": item.post_count_text,
+        "url": item.url,
+        "imageUrls": list(item.image_urls),
+        "isAiTrend": item.is_ai_trend,
+    }
+
+
+def explore_items_to_data(items: Iterable[ExploreItem]) -> List[Dict[str, Any]]:
+    """Serialize ExploreItem objects to Python dicts."""
+    return [explore_item_to_dict(item) for item in items]
+
+
+def explore_items_to_json(items: Iterable[ExploreItem]) -> str:
+    """Serialize ExploreItem objects to pretty JSON."""
+    return json.dumps(explore_items_to_data(items), ensure_ascii=False, indent=2)
 
 
 def bookmark_folder_to_dict(folder: BookmarkFolder) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add ExploreItem parsing/serialization for X Explore TimelineTrend entries
- add `twitter explore --section news|trending|for-you|sports|entertainment`
- add `twitter today-news` plus hidden `todaynew` alias for news
- document structured Explore output and add unit coverage

## Verification
- `uv sync --extra dev`
- `uv run ruff check .`
- `uv run mypy twitter_cli`
- `uv run pytest -q`
- `uv run python -m twitter_cli.cli explore --section news --max 2 --json`