### PR TITLE
 feat: add author follower and following counts to serialized output

### DIFF
--- a/twitter_cli/models.py
+++ b/twitter_cli/models.py
@@ -16,6 +16,8 @@ class Author:
     screen_name: str
     profile_image_url: str = ""
     verified: bool = False
+    followers_count: int = 0
+    following_count: int = 0
 
 
 @dataclass

--- a/twitter_cli/parser.py
+++ b/twitter_cli/parser.py
@@ -107,6 +107,8 @@ def _extract_author(user_data, user_legacy):
             or user_legacy.get("profile_image_url_https", "")
         ),
         verified=bool(user_data.get("is_blue_verified") or user_legacy.get("verified", False)),
+        followers_count=_parse_int(user_legacy.get("followers_count"), 0),
+        following_count=_parse_int(user_legacy.get("friends_count"), 0),
     )
 
 

--- a/twitter_cli/serialization.py
+++ b/twitter_cli/serialization.py
@@ -20,6 +20,8 @@ def tweet_to_dict(tweet: Tweet) -> Dict[str, Any]:
             "screenName": tweet.author.screen_name,
             "profileImageUrl": tweet.author.profile_image_url,
             "verified": tweet.author.verified,
+            "followers": tweet.author.followers_count,
+            "following": tweet.author.following_count,
         },
         "metrics": {
             "likes": tweet.metrics.likes,


### PR DESCRIPTION
 ## Summary
  Expose author follower/following counts in parsed tweet output.

  This adds `followers_count` and `following_count` to the `Author` model,
  parses them
  from Twitter user legacy fields (`followers_count` and `friends_count`), and
  includes
  them in serialized tweet output as `author.followers` and `author.following`.

  ## Changes

  | File | Change |
  | --- | --- |
  | `twitter_cli/models.py` | Added `followers_count` and `following_count`  fields to the `Author` dataclass. |
  | `twitter_cli/parser.py` | Parse `followers_count` and `friends_count` from  `user_legacy` into the `Author` model. |
  | `twitter_cli/serialization.py` | Include `author.followers` and  `author.following` in `tweet_to_dict()` output. |

  ## Impact

  | Area | Before | After |
  | --- | --- | --- |
  | `Author` model | No follower/following counts | Includes `followers_count`  and `following_count` |
  | Parsed author metadata | Name, screen name, avatar, verified | Adds follower  and following counts |
  | Structured output | No `author.followers` / `author.following` | Both fields  available in serialized output |

  ## Notes
  - `followers_count` is sourced from Twitter's `user_legacy.followers_count`
  - `following_count` is sourced from Twitter's `user_legacy.friends_count`
  - Default value is `0` when the source field is missing or unparsable

