### PR TITLE
fix(search): send auth cookies when fetching x.com home for ClientTransaction init (fixes SearchTimeline 404)

### DIFF
--- a/twitter_cli/client.py
+++ b/twitter_cli/client.py
@@ -1103,6 +1103,9 @@ class TwitterClient:
             # a different TLS fingerprint on the same IP — a detection vector.
             cffi_session = _get_cffi_session()
             ct_headers = _gen_ct_headers()
+            # Send auth cookies: X's guest homepage no longer embeds ondemand.s,
+            # so a cookieless fetch fails CT init and SearchTimeline returns 404.
+            ct_headers["Cookie"] = self._cookie_string or "auth_token=%s; ct0=%s" % (self._auth_token, self._ct0)
             home_page = cffi_session.get(
                 "https://x.com", headers=ct_headers, timeout=10,
             )


### PR DESCRIPTION
## Problem

`twitter search ...` returns **HTTP 404** for every query (with or without filters), while `user-posts` / `user` / `tweet` / `feed` all work. Upgrading doesn't help (PyPI 0.8.5 and `main` 0.8.6 share this code).

## Root cause

X enforces the `x-client-transaction-id` anti-bot header on **SearchTimeline** specifically (other operations tolerate its absence, which is why only `search` 404s).

`_init_client_transaction()` fetches `https://x.com` with **guest headers only** (no auth cookies) to locate the `ondemand.s` file:

```python
ct_headers = _gen_ct_headers()
home_page = cffi_session.get("https://x.com", headers=ct_headers, timeout=10)
...
ondemand_url = get_ondemand_file_url(response=home_page_response)
```

X's current **guest** homepage (~35 KB) no longer embeds the `ondemand.s` reference, so `get_ondemand_file_url()` raises `'NoneType' object has no attribute 'group'`. CT init then silently fails (the `WARNING Failed to init ClientTransaction: 'NoneType' ...` line), no `x-client-transaction-id` header is sent, and SearchTimeline returns 404.

The **logged-in** homepage (~271 KB) still embeds `ondemand.s`, so fetching it with the session cookies makes CT init succeed.

I also ruled out a stale `SearchTimeline` queryId: even injecting x.com's current live queryId still 404s until the transaction-id header is present — so the header is the real cause.

## Fix

Send the auth cookies on the home / ondemand fetches (both use `ct_headers`). This mirrors the cookie idiom already used in `_build_headers`:

```python
ct_headers = _gen_ct_headers()
ct_headers["Cookie"] = self._cookie_string or "auth_token=%s; ct0=%s" % (self._auth_token, self._ct0)
```

## Verification

- Guest fetch: home = 35 KB, `get_ondemand_file_url` → `NoneType.group`.
- Authed fetch: home = 271 KB, ondemand resolved (e.g. `.../ondemand.s.964027da.js`), CT init OK.
- After the change, `twitter search "openai"` and `twitter search "codex" --from thsottiaux --min-likes 100` return results instead of 404.
