### PR TITLE
fix: bootstrap ClientTransaction from responsive home

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -266,6 +266,44 @@ class TestUpdateFeaturesFromHtml:
 # ── TwitterClient._build_headers ─────────────────────────────────────────
 
 class TestBuildHeaders:
+    @patch("twitter_cli.client._update_features_from_html")
+    @patch("twitter_cli.client.ClientTransaction")
+    @patch(
+        "twitter_cli.client.get_ondemand_file_url",
+        return_value="https://abs.twimg.com/responsive-web/client-web/ondemand.s.js",
+    )
+    @patch("twitter_cli.client._gen_ct_headers", return_value={"User-Agent": "test"})
+    @patch("twitter_cli.client._get_cffi_session")
+    def test_client_transaction_bootstraps_from_responsive_home_page(
+        self,
+        mock_session_factory,
+        _mock_headers,
+        _mock_ondemand_url,
+        mock_client_transaction,
+        mock_update_features,
+    ):
+        home_page = MagicMock(content=b"<html></html>", text="<html></html>")
+        ondemand_file = MagicMock(text="ondemand bundle")
+        mock_session_factory.return_value.get.side_effect = [home_page, ondemand_file]
+
+        client = TwitterClient.__new__(TwitterClient)
+        client._ct_init_attempted = False
+        client._client_transaction = None
+        client._load_ct_cache = MagicMock(return_value=False)
+        client._save_ct_cache = MagicMock()
+
+        client._ensure_client_transaction()
+
+        first_request = mock_session_factory.return_value.get.call_args_list[0]
+        assert first_request.args[0] == "https://x.com/home"
+        assert first_request.kwargs == {
+            "headers": {"User-Agent": "test"},
+            "timeout": 10,
+        }
+        mock_client_transaction.assert_called_once()
+        mock_update_features.assert_called_once_with("<html></html>")
+        client._save_ct_cache.assert_called_once_with("<html></html>", "ondemand bundle")
+
     @patch("twitter_cli.client._get_cffi_session")
     @patch("twitter_cli.client._gen_ct_headers", return_value={})
     def test_required_headers_present(self, mock_ct_headers, mock_session):

--- a/twitter_cli/client.py
+++ b/twitter_cli/client.py
@@ -1104,7 +1104,7 @@ class TwitterClient:
             cffi_session = _get_cffi_session()
             ct_headers = _gen_ct_headers()
             home_page = cffi_session.get(
-                "https://x.com", headers=ct_headers, timeout=10,
+                "https://x.com/home", headers=ct_headers, timeout=10,
             )
             home_page_response = bs4.BeautifulSoup(home_page.content, "html.parser")
             ondemand_url = get_ondemand_file_url(response=home_page_response)


### PR DESCRIPTION
## Summary

- fetch https://x.com/home when bootstrapping ClientTransaction
- keep auth cookies out of the HTML bootstrap request
- add a regression test covering the responsive home URL, ondemand bundle lookup, feature refresh, and cache write

The root path now serves a lightweight logged-out shell without the ondemand.s bundle. The responsive home path still exposes the assets required to generate x-client-transaction-id, which SearchTimeline requires.

This supersedes the closed #71 with the narrower path-only fix discussed there.

Fixes #69.
Fixes #73.

## Validation

- 243 passed, 6 deselected
- ruff check .
- mypy twitter_cli