### PR TITLE
fix: send auth cookies when fetching x.com home for ClientTransaction init (fixes #78)

### DIFF
--- a/twitter_cli/client.py
+++ b/twitter_cli/client.py
@@ -1103,8 +1103,9 @@ class TwitterClient:
             # a different TLS fingerprint on the same IP — a detection vector.
             cffi_session = _get_cffi_session()
             ct_headers = _gen_ct_headers()
+            ct_headers["Cookie"] = "auth_token={}; ct0={}".format(self._auth_token, self._ct0)
             home_page = cffi_session.get(
-                "https://x.com", headers=ct_headers, timeout=10,
+                "https://x.com/home", headers=ct_headers, timeout=10,
             )
             home_page_response = bs4.BeautifulSoup(home_page.content, "html.parser")
             ondemand_url = get_ondemand_file_url(response=home_page_response)


### PR DESCRIPTION
## Summary

Fixes #78 (same root cause as #74/#69/#73): `twitter search` returns HTTP 404
because `ClientTransaction` init silently fails and falls back to a stale
hardcoded `SearchTimeline` queryId.

## Root cause

`_ensure_client_transaction()` fetches `https://x.com` with a **fresh,
unauthenticated** `curl_cffi` session (no cookies at all — `_gen_ct_headers()`
only sets generic browser headers). Since the x.com homepage redesign, the
logged-out response no longer contains the `,<id>:"ondemand.s"` webpack chunk
marker that `get_ondemand_file_url()` searches for, so parsing fails with
`'NoneType' object has no attribute 'group'`. The exception is swallowed by
the broad `except` in `_ensure_client_transaction`, so it only logs a warning
and the client silently falls back to the stale hardcoded queryId — which
Twitter now 404s.

I confirmed this by running `get_ondemand_file_url()` directly against HTML
fetched two ways: an unauthenticated request to `x.com` (fails — no
`ondemand.s` marker in the response) vs. an authenticated request to
`x.com/home` with real session cookies (succeeds).

## Fix

Attach the client's own `auth_token`/`ct0` cookies to the `ClientTransaction`
bootstrap request, and fetch `x.com/home` (where the authenticated app shell
actually lives) instead of bare `x.com`.

This overlaps with #71 (closed, unmerged) which proposed the same cookie fix;
this PR also corrects the request target to `/home`.

## Verification

Tested against two different accounts (a brand-new account and one 2+ years
old, to rule out account-age throttling) — both reproduced the 404 pre-patch
and both returned real search results post-patch:

```
$ twitter search "seedance prompt" -n 3
# pre-patch: ok: false, error: Twitter API error (HTTP 404)
# post-patch: ok: true, data: [...3 real tweets with full text/media/metrics...]
```

No changes to public API, no new dependencies.