### PR TITLE
fix: fetch authenticated /home for ClientTransaction init (new x-web frontend broke posting)

### DIFF
--- a/twitter_cli/client.py
+++ b/twitter_cli/client.py
@@ -1103,8 +1103,15 @@ class TwitterClient:
             # a different TLS fingerprint on the same IP — a detection vector.
             cffi_session = _get_cffi_session()
             ct_headers = _gen_ct_headers()
+            # Logged-out x.com serves the new "x-web" frontend, which no longer
+            # references ondemand.s; the authenticated /home page still serves
+            # the legacy responsive-web frontend the CT algorithm needs.
+            authed_headers = dict(ct_headers)
+            authed_headers["Cookie"] = self._cookie_string or (
+                "auth_token=%s; ct0=%s" % (self._auth_token, self._ct0)
+            )
             home_page = cffi_session.get(
-                "https://x.com", headers=ct_headers, timeout=10,
+                "https://x.com/home", headers=authed_headers, timeout=10,
             )
             home_page_response = bs4.BeautifulSoup(home_page.content, "html.parser")
             ondemand_url = get_ondemand_file_url(response=home_page_response)


### PR DESCRIPTION
## Problem

Since early August 2026, every invocation logs:

```
WARNING twitter_cli.client: Failed to init ClientTransaction: 'NoneType' object has no attribute 'group'
```

and `CreateTweet` fails most of the time with `Twitter API error (HTTP 0): Failed to create tweet` (a small fraction of posts slip through), while all read endpoints keep working.

## Root cause

Logged-out `x.com` now serves X's new **x-web** frontend (assets under `abs.twimg.com/x-web/x-web/`). That page no longer references `ondemand.s.<hash>.js`, so `x_client_transaction.get_ondemand_file_url` raises (`ON_DEMAND_FILE_REGEX` finds no match — the `.group` on `None`). Without a `ClientTransaction`, requests go out with no `X-Client-Transaction-Id` header and X rejects tweet creation. Upstream `xclienttransaction` 1.0.3 (latest) has no fix yet.

## Fix

The **authenticated** `/home` page still serves the legacy responsive-web frontend containing all three signing inputs (twitter-site-verification meta, `loading-x-anim` SVGs, `ondemand.s` reference). This PR makes `_ensure_client_transaction` fetch `https://x.com/home` with the session's auth cookies. Auth is always available at that point since init runs from `TwitterClient.__init__`. The cache path is unaffected (it stores raw HTML/JS and bypasses `get_ondemand_file_url`).

## Verification

- Warning gone; `ClientTransaction initialized` logged.
- `twitter post` + `twitter delete` round-trip succeeds (was failing with HTTP 0 before).
- Read endpoints unaffected.

Note: if/when X migrates the logged-in page to x-web as well, the regexes will need a real update in `xclienttransaction`; this keeps the CLI working until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aa1vBaCBrYHvoBgp8SZLoV