### PR TITLE
fix(graphql): refresh FALLBACK_QUERY_IDS against live twitter-openapi IDs (complements #79/#80)

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -208,7 +208,7 @@ class TestBuildGraphqlUrl:
 
     def test_searchtimeline_fallback_query_id_regression(self):
         """Keep SearchTimeline fallback aligned with the live operation after issue #39."""
-        assert FALLBACK_QUERY_IDS["SearchTimeline"] == "VhUd6vHVmLBcw0uX-6jMLA"
+        assert FALLBACK_QUERY_IDS["SearchTimeline"] == "Yw6L66Pw54NHKuq4Dp7b4Q"
 
 
 # ── _best_chrome_target ──────────────────────────────────────────────────

--- a/twitter_cli/graphql.py
+++ b/twitter_cli/graphql.py
@@ -26,27 +26,31 @@ TWITTER_OPENAPI_URL = (
 )
 
 # ── Fallback (hardcoded) queryIds ────────────────────────────────────────
+# NOTE: refreshed against twitter-openapi placeholder.json on 2026-08-09.
+# X rotates these IDs regularly; refresh by fetching
+# https://raw.githubusercontent.com/fa0311/twitter-openapi/refs/heads/main/src/config/placeholder.json
+# and updating any value that drifted.
 FALLBACK_QUERY_IDS = {
-    "HomeTimeline": "c-CzHF1LboFilMpsx4ZCrQ",
-    "HomeLatestTimeline": "BKB7oi212Fi7kQtCBGE4zA",
-    "UserByScreenName": "1VOOyvKkiI3FMmkeDNxM9A",
-    "UserTweets": "q6xj5bs0hapm9309hexA_g",
-    "TweetDetail": "xd_EMdYvB9hfZsZ6Idri0w",
-    "Likes": "lIDpu_NWL7_VhimGGt0o6A",
-    "SearchTimeline": "VhUd6vHVmLBcw0uX-6jMLA",
-    "Bookmarks": "2neUNDqrrFzbLui8yallcQ",
-    "ListLatestTweetsTimeline": "RlZzktZY_9wJynoepm8ZsA",
-    "Followers": "IOh4aS6UdGWGJUYTqliQ7Q",
-    "Following": "zx6e-TLzRkeDO_a7p4b3JQ",
-    "CreateTweet": "IID9x6WsdMnTlXnzXGq8ng",
+    "HomeTimeline": "7zlnp2TxC044W4C1ZUJMHw",
+    "HomeLatestTimeline": "0dateTVgvXjpkf7kyBZy0g",
+    "UserByScreenName": "IGgvgiOx4QZndDHuD3x9TQ",
+    "UserTweets": "36rb3Xj3iJ64Q-9wKDjCcQ",
+    "TweetDetail": "oCon7R-cgWRFy6EfZjaKfg",
+    "Likes": "rk2aeVVvKsyUdG3jf5uiLw",
+    "SearchTimeline": "Yw6L66Pw54NHKuq4Dp7b4Q",
+    "Bookmarks": "XD0ViOeSOW4YoeNTGjVaYw",
+    "ListLatestTweetsTimeline": "FVWmROVvhgjRPC-4jAUh8A",
+    "Followers": "_orfRBQae57vylFPH0Huhg",
+    "Following": "F42cDX8PDFxkbjjq6JrM2w",
+    "CreateTweet": "5CdvsV_zjv4L64XFifAglw",
     "DeleteTweet": "VaenaVgh5q5ih7kvyVjgtg",
     "FavoriteTweet": "lI07N6Otwv1PhnEgXILM7A",
     "UnfavoriteTweet": "ZYKSe-w7KEslx3JhSIk5LA",
-    "CreateRetweet": "ojPdsZsimiJrUGLR1sjUtA",
-    "DeleteRetweet": "iQtK4dl5hBmXewYZuEOKVw",
+    "CreateRetweet": "mbRO74GrOvSfRcJnlMapnQ",
+    "DeleteRetweet": "ZyZigVsNiFO6v1dEks1eWg",
     "CreateBookmark": "aoDbu3RHznuiSkQ9aNM67Q",
     "DeleteBookmark": "Wlmlj2-xzyS1GN3a6cj-mQ",
-    "TweetResultByRestId": "7xflPyRiUxGVbJd4uWmbfg",
+    "TweetResultByRestId": "tCVRZ3WCvoj0BVO7BKnL-Q",
     "BookmarkFoldersSlice": "i78YDd0Tza-dV4SYs58kRg",
     "BookmarkFolderTimeline": "hNY7X2xE2N7HVF6Qb_mu6w",
 }


### PR DESCRIPTION
## Problem

`tw search`, `tw feed`, `tw bookmarks`, and most other read commands currently fail with `HTTP 404` / `Query: Unspecified` against live X.

Root cause: X rotated nearly all GraphQL `queryId`s. The hardcoded `FALLBACK_QUERY_IDS` in `twitter_cli/graphql.py` have drifted (both the 0.8.5 release and current `main` are stale), so every request that depends on a fallback ID is rejected.

User-visible symptom reported in #78: `twitter search` returns 404 even with valid cookies, even with PRs #79 + #80 applied (those fix the `x-client-transaction-id` init; the queryId itself is also stale).

## Fix

Refreshed 15 of 22 fallback IDs against the community-maintained `twitter-openapi` `placeholder.json` — the **same source `_fetch_from_github()` already trusts at runtime** (`twitter_cli/graphql.py:TWITTER_OPENAPI_URL`). So this is a snapshot of exactly what dynamic resolution would have fetched, just with the network call removed.

Ops rotated (stale → live):

| Op | Status |
|---|---|
| HomeTimeline, HomeLatestTimeline, UserByScreenName, UserTweets, TweetDetail, Likes | rotated |
| **SearchTimeline** ✱ | rotated (this is the one in #78) |
| Bookmarks, ListLatestTweetsTimeline, Followers, Following | rotated |
| CreateTweet, CreateRetweet, DeleteRetweet, TweetResultByRestId | rotated |
| DeleteTweet, FavoriteTweet, UnfavoriteTweet, CreateBookmark, DeleteBookmark | unchanged |
| BookmarkFoldersSlice, BookmarkFolderTimeline | no live value in upstream; kept as-is |

## Verification

End-to-end on a live account (cookies from `~/.agent-reach/twitter.env`):

```
$ tw search "AI agents" --json -n 5 --type latest --since 2026-08-02
rc: 0, ok: true          ← previously: rc:1, HTTP 404
```

Test suite on this branch:

```
$ pytest tests/test_client.py
86 passed in 7.60s
```

`tests/test_client.py::test_searchtimeline_fallback_query_id_regression` updated to pin the new live ID — its original value (`VhUd6vHVmLBcw0uX-6jMLA`) was itself stale.

## Relation to open PRs

- **#79 / #80** (fetch `/home` with auth cookies for ClientTransaction init): fixes the `x-client-transaction-id` header side.
- **This PR**: fixes the queryId side.

**Both are needed for `tw search` to work** — with only #79/#80 you'd get `404` on a stale queryId; with only this PR you'd get rejected for a missing/invalid transaction ID. I applied both locally to verify `tw search` end-to-end, but they review independently — whichever lands first unblocks half the failure, the second one finishes it.

## Follow-up (not in this PR)

X rotates these IDs on a regular cadence. Long-term, consider seeding `_cached_query_ids` from the runtime-fetched `placeholder.json` *before* falling back to the hardcoded dict — currently `_resolve_query_id(prefer_fallback=True)` (the default) returns the hardcoded value immediately and never consults the live source, which is how this drift persisted. Added a comment atop `FALLBACK_QUERY_IDS` with the refresh URL.
