### PR TITLE
fix: send session cookies when fetching x.com for ClientTransaction init

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1545,3 +1545,54 @@ class TestFetchSearchUsesPost:
 
         assert captured.get("product") == "Latest"
         assert captured.get("querySource") == "typed_query"
+
+
+# ── TwitterClient._ensure_client_transaction ─────────────────────────────
+
+class TestEnsureClientTransaction:
+    """The x.com fetch must be authenticated.
+
+    Anonymous requests receive the logged-out landing page, which carries no
+    ondemand.s marker, so get_ondemand_file_url() fails and every subsequent
+    API call goes out without an x-client-transaction-id header.
+    """
+
+    def _make_client(self):
+        client = TwitterClient.__new__(TwitterClient)
+        client._auth_token = "test_token"
+        client._ct0 = "test_ct0"
+        client._cookie_string = None
+        client._client_transaction = None
+        client._ct_init_attempted = False
+        return client
+
+    @patch("twitter_cli.client._gen_ct_headers", return_value={})
+    @patch("twitter_cli.client._get_cffi_session")
+    def test_homepage_fetch_sends_cookies(self, mock_session, mock_ct_headers):
+        session = MagicMock()
+        session.get = MagicMock(side_effect=Exception("stop after first fetch"))
+        mock_session.return_value = session
+
+        client = self._make_client()
+        client._load_ct_cache = lambda: False
+        client._ensure_client_transaction()
+
+        _, kwargs = session.get.call_args
+        cookie = kwargs["headers"]["Cookie"]
+        assert "auth_token=test_token" in cookie
+        assert "ct0=test_ct0" in cookie
+
+    @patch("twitter_cli.client._gen_ct_headers", return_value={})
+    @patch("twitter_cli.client._get_cffi_session")
+    def test_full_cookie_string_preferred(self, mock_session, mock_ct_headers):
+        session = MagicMock()
+        session.get = MagicMock(side_effect=Exception("stop after first fetch"))
+        mock_session.return_value = session
+
+        client = self._make_client()
+        client._cookie_string = "auth_token=a; ct0=b; guest_id=c"
+        client._load_ct_cache = lambda: False
+        client._ensure_client_transaction()
+
+        _, kwargs = session.get.call_args
+        assert kwargs["headers"]["Cookie"] == "auth_token=a; ct0=b; guest_id=c"

--- a/twitter_cli/client.py
+++ b/twitter_cli/client.py
@@ -1103,6 +1103,13 @@ class TwitterClient:
             # a different TLS fingerprint on the same IP — a detection vector.
             cffi_session = _get_cffi_session()
             ct_headers = _gen_ct_headers()
+            # x.com serves the logged-out landing page to anonymous requests,
+            # and that page contains no ondemand.s marker for
+            # get_ondemand_file_url() to match. Send the session cookies so we
+            # receive the authenticated app shell instead.
+            ct_headers["Cookie"] = self._cookie_string or (
+                "auth_token=%s; ct0=%s" % (self._auth_token, self._ct0)
+            )
             home_page = cffi_session.get(
                 "https://x.com", headers=ct_headers, timeout=10,
             )


### PR DESCRIPTION
## Problem

`_ensure_client_transaction()` fetches `https://x.com` to extract the `ondemand.s` bundle used to build `x-client-transaction-id`, but that request goes out **without cookies**. x.com serves the logged-out landing page to anonymous requests, and that page contains no `ondemand.s` marker.

So `ON_DEMAND_FILE_REGEX.search()` returns `None`, and `get_ondemand_file_url()` raises:

```
Failed to init ClientTransaction: 'NoneType' object has no attribute 'group'
```

`_client_transaction` stays `None`, so every subsequent API call is sent without the `x-client-transaction-id` header. X answers those with **HTTP 404** — which is why the failure shows up as a 404 on `SearchTimeline` and on account-verification endpoints rather than as an auth error, and why retries never help.

## Evidence

Same request via `curl_cffi` with `impersonate="chrome"`, only difference being cookies:

| Request | Status | Body | `ondemand` occurrences | Marker matched |
|---|---|---|---|---|
| Anonymous | 200 | ~35 KB | 0 | no |
| With `auth_token` + `ct0` | 200 | ~278 KB | 233 | yes |

The anonymous response is a valid 200, which is why this fails silently at a warning level instead of surfacing as a request error.

## Fix

Set the `Cookie` header on the init fetch. `_build_headers()` already constructs exactly this value for API calls, so this reuses the same `self._cookie_string or auth_token=…; ct0=…` form — no new configuration or code paths.

Verified end-to-end after the change: `twitter search` returns live results, and `ClientTransaction initialized for x-client-transaction-id` is logged.

## Tests

Two regression tests added to `TestEnsureClientTransaction`, covering the derived cookie pair and the full `_cookie_string` passthrough. Both fail on `main` and pass with the fix:

```
$ uv run pytest tests/test_client.py -k EnsureClientTransaction -q   # before
2 failed
$ uv run pytest tests/test_client.py -q                              # after
88 passed
```

`uv run ruff check .` and `uv run mypy twitter_cli` both clean.

Fixes #78
Fixes #73
Fixes #69